### PR TITLE
Added check to ensure that the document root and plugin app dir live on the same disk

### DIFF
--- a/public/class-reactpress-public.php
+++ b/public/class-reactpress-public.php
@@ -129,8 +129,12 @@ class Reactpress_Public {
 			$appname = $current_app['appname'];
 			$plugin_app_dir_url = escapeshellcmd(REPR_PLUGIN_PATH . "apps/{$appname}/");
 
-			$relative_apppath = explode($document_root, $plugin_app_dir_url)[1];
-
+			$relative_apppath = escapeshellcmd("/wp-content/plugins/reactpress/apps/{$appname}/");
+			
+			if(strpos($plugin_app_dir_url, $document_root) === 0) {
+				$relative_apppath = explode($document_root, $plugin_app_dir_url)[1];
+			}
+			
 			$react_app_build = $plugin_app_dir_url . 'build/';
 			$manifest_url = $react_app_build . 'asset-manifest.json';
 


### PR DESCRIPTION
In most cases, the document_root and plugin_app_dir_url are going to be on the same disk and the explode works as expected.  However with some WordPress hosting sites like WPEngine, that is not always the case.  This puts a check in place to use the default location for ReactPress if they're not on the same disk.
