### PR TITLE
Fixes #30 Use relative template file names

### DIFF
--- a/admin/Admin.php
+++ b/admin/Admin.php
@@ -186,8 +186,9 @@ class Admin {
 	 * @since 1.0.0
 	 */
 	public function repr_add_page_template($templates) {
-		$templates[REPR_PLUGIN_PATH . 'templates/empty-react-page-template.php'] = __('ReactPress Canvas', 'text-domain');
-		$templates[REPR_PLUGIN_PATH . 'templates/react-page-template.php'] = __('ReactPress Full Width', 'text-domain');
+	    // Use relative paths for the templates and then resolve them at runtime.
+	    $templates['templates/empty-react-page-template.php'] = __('ReactPress Canvas', 'text-domain');
+	    $templates['templates/react-page-template.php'] = __('ReactPress Full Width', 'text-domain');
 
 		return $templates;
 	}
@@ -539,8 +540,9 @@ class Admin {
 					'post_author' => '1',
 					'post_content' => REPR_REACT_ROOT_TAG,
 					'post_type' => "page",
-					// Assign page template
-					'page_template'  => REPR_PLUGIN_PATH . 'templates/react-page-template.php',
+				    // Assign page template using the relative path, it will be
+				    // resolved to the fully qualified name at run-time
+				    'page_template'  => 'templates/react-page-template.php',
 				)
 			);
 			if ($result) {

--- a/public/User.php
+++ b/public/User.php
@@ -106,11 +106,27 @@ class User {
 		if (is_page()) {
 			$meta = get_post_meta(get_the_ID());
 
-			if (
-				!empty($meta['_wp_page_template'][0]) && $meta['_wp_page_template'][0] != $template && 'default' !== $meta['_wp_page_template'][0] &&	strpos($meta['_wp_page_template'][0], 'react-page-template.php')
-			) {
-				$template = $meta['_wp_page_template'][0];
-			}
+			// Check if the page template is a Reactpress template
+			if (!empty($meta['_wp_page_template'][0]) &&
+			    $meta['_wp_page_template'][0] != $template &&
+			    'default' !== $meta['_wp_page_template'][0] &&
+			    strpos($meta['_wp_page_template'][0], 'react-page-template.php')
+			    ) {
+			        // At this point we know it's a Reactpress template
+			        $template = $meta['_wp_page_template'][0];
+
+			        // determine the location of the templates folder reference
+			        $ndx = strpos($template, 'templates/');
+
+			        // If it's not at the beginning
+			        if (0 != $ndx) {
+			            // change the template to be relative to the plugin's folder (i.e., templates/react-page-template.php)
+			            $template = substr($template, $ndx);
+			        }
+
+			        // Prepend the real path at runtime
+			        $template = REPR_PLUGIN_PATH . $template;
+			    }
 		}
 
 		return $template;


### PR DESCRIPTION
Change to use relative file names for the template references and make them fully qualified by prefixing the plugin folder name at run-time.