### PR TITLE
Fix namespace references for repr_log()

### DIFF
--- a/admin/Controller.php
+++ b/admin/Controller.php
@@ -16,6 +16,8 @@ namespace ReactPress\Admin;
 use LengthException;
 use ReactPress\Admin\Utils;
 
+use function \repr_log;
+
 class Controller {
 
   // # Controller functions

--- a/public/User.php
+++ b/public/User.php
@@ -25,7 +25,7 @@ namespace ReactPress\User;
 
 use ReactPress\Admin\Utils;
 
-use function ReactPress\Admin\repr_log;
+use function \repr_log;
 
 class User {
 
@@ -94,7 +94,7 @@ class User {
 	}
 
 	/**
-	 * Add the type="module" attribute to the script tag, for 
+	 * Add the type="module" attribute to the script tag, for
 	 * ReactPress apps, to remove some errors with Vite.
 	 */
 	function add_type_module_to_scripts($tag, $handle, $src) {
@@ -149,7 +149,7 @@ class User {
 	/**
 	 * Load react app files im page should contain a react app.
 	 * (C) Ben Broide https://medium.com/swlh/wordpress-create-react-app-integration-30b41657b79e
-	 * 
+	 *
 	 * @return bool|void
 	 * @since 1.0.0
 	 */
@@ -282,7 +282,7 @@ class User {
 
 	/**
 	 * Add new rewrite rules for every app to make react router usable.
-	 * 
+	 *
 	 * @since 1.4.0
 	 */
 	public function add_repr_apps_rewrite_rules() {


### PR DESCRIPTION
Fixes #57
With the "Fix security issues" change, repr_log() was moved from Admin.php to reactpress.php but the namespace reference in User.php was not updated, or added to Controller.php.