### PR TITLE
Fixes #41 - Trim URL slug's leading and trailing slashes for ReactRouter path so full page reload finds the base slug and does not 404.

### DIFF
--- a/admin/Controller.php
+++ b/admin/Controller.php
@@ -288,7 +288,16 @@ class Controller {
               throw new LengthException('Client-side routing is only possible on one single page.');
             }
             foreach ($el['pages'] as $page) {
-              add_rewrite_rule('^' . wp_make_link_relative($page['permalink']) . '/(.*)?', 'index.php?pagename=' . wp_make_link_relative($page['permalink']), 'top');
+              add_rewrite_rule(
+                '^' .
+                // Trim leading and trailing slashes to get `^foo/bar/(.*)?` not `^/foo/bar//(.*)?`
+                trim(wp_make_link_relative($page['permalink']), '/') .
+                '/(.*)?',
+                'index.php?pagename=' .
+                // Trim leading and trailing slashes to get `index.php?pagename=foo/bar` not `index.php?pagename=/foo/bar/`
+                trim(wp_make_link_relative($page['permalink']), '/'),
+                'top'
+              );
               Utils::set_public_url_for_dev_server($appname, $page['permalink']);
             }
             flush_rewrite_rules();

--- a/public/User.php
+++ b/public/User.php
@@ -331,7 +331,7 @@ class User {
 		return [$js_files, $css_files];
 	}
 
-    /**
+	/**
 	 * Add new rewrite rules for every app to make react router usable.
 	 *
 	 * @since 1.4.0
@@ -351,10 +351,12 @@ class User {
 		foreach ($permalinks as $permalink) {
 			add_rewrite_rule(
 				'^' .
-					wp_make_link_relative($permalink) .
-					'/(.*)?',
+				// Trim leading and trailing slashes to get `^foo/bar/(.*)?` not `^/foo/bar//(.*)?`
+				trim(wp_make_link_relative($permalink), '/') .
+				'/(.*)?',
 				'index.php?pagename=' .
-					wp_make_link_relative($permalink),
+				// Trim leading and trailing slashes to get `index.php?pagename=foo/bar` not `index.php?pagename=/foo/bar/`
+				trim(wp_make_link_relative($permalink), '/'),
 				'top'
 			);
 		}


### PR DESCRIPTION
@rockiger This PR fixes #41 for me. It looks like the `permalink` slug I have is in the format of: `/foo/`

Using this to output the site's rewrite rules:
```php
<?php print_r(get_option('rewrite_rules')); ?>
```
The old code would generate this rewrite rule:
```php
[^/foo//(.*)?] => index.php?pagename=/foo/
```

As @Maadhav mentioned in #41, the `//` is not a valid regex. I'm not sure why you were not able to reproduce this. There may be a plugin or hosting issue that is adding the `/` before and after the page slug. This PR will trim off the leading and trailing `/` from the page slug, generating the correct rewrite rule:
```php
[^foo/(.*)?] => index.php?pagename=foo
```

After that, page reloads work correctly when the ReactRouter has added paths to the base page URL.