### PR TITLE
Prevent blank page caused by invalid graphql_general_settings in public/User.php

### DIFF
--- a/public/User.php
+++ b/public/User.php
@@ -215,12 +215,23 @@ class User {
 			}
 			// Variables for app use
 			$current_user = wp_get_current_user();
+
+			$graphql_general_settings = get_option('graphql_general_settings', false);
+
+			// Set default GraphQL endpoint URL as fallback in case no custom setting exists.
+			// This matches WPGraphQL’s default endpoint URL.
+			$graphql_endpoint = 'graphql';
+
+			if (is_array($graphql_general_settings) && !empty($graphql_general_settings['graphql_endpoint'])) {
+    			$graphql_endpoint = $graphql_general_settings['graphql_endpoint'];
+			}
+
 			unset($current_user->user_pass); // Don't show encypted password for security reasons.
 			wp_localize_script('rp-react-app-asset-0-0', 'reactPress', array(
 				'api' => [
 					'nonce' => wp_create_nonce('wp_rest'),
 					'rest_url' => esc_url_raw(rest_url()),
-					'graphql_url' => esc_url_raw(site_url(get_option('graphql_general_settings', ["graphql_endpoint" => 'graphql'])['graphql_endpoint'])),
+					'graphql_url' => esc_url_raw(site_url($graphql_endpoint)),
 				],
 				'post' => $post,
 				'user' => $current_user,


### PR DESCRIPTION
Today, after installing the [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) plugin on my WordPress server running ReactPress v3.4.0, I noticed that pages using ReactPress were rendering blank. Checking the PHP error log, I found the following stack trace:
```
Stack trace:
#0 /var/www/html/wp-content/plugins/reactpress/public/User.php(91): ReactPress\User\User->repr_load_react_app()
#1 /var/www/html/wp-includes/class-wp-hook.php(324): ReactPress\User\User->enqueue_scripts('')
#2 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#3 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#4 /var/www/html/wp-includes/script-loader.php(2299): do_action('wp_enqueue_scri...')
#5 /var/www/html/wp-includes/class-wp-hook.php(324): wp_enqueue_scripts('')
#6 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#7 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#8 /var/www/html/wp-includes/general-template.php(3192): do_action('wp_head')
#9 /var/www/html/wp-includes/template-canvas.php(17): wp_head()
#10 /var/www/html/wp-includes/template-loader.php(106): include('/var/www/html/w...')
#11 /var/www/html/wp-blog-header.php(19): require_once('/var/www/html/w...')
#12 /var/www/html/index.php(17): require('/var/www/html/w...')
#13 {main}
  thrown in /var/www/html/wp-content/plugins/reactpress/public/User.php on line 223
```
Oddly enough, the crash occurred even after disabling and uninstalling WPGraphQL.

## Why this crashes

After some debugging, I discovered the following behavior of `get_option('graphql_general_settings')`:

- If WPGraphQL has never been installed, because the option does not exist yet, it returns the default passed to `get_option()`. In this case `['graphql_endpoint' => 'graphql']` is used, so the code works as expected.
- **It returns an empty string (`''`) if WPGraphQL has been installed but its settings page has never been saved. [In this case](https://github.com/rockiger/reactpress/pull/78/files#diff-68e361992b4a17716f6eaea5d0c808023f9ddcb898e5636733df11a657c426ceL223), WordPress does not use the default value. As a result, the code tries to access `['graphql_endpoint']` on a string, which causes a fatal error:** ```Uncaught TypeError: Cannot access offset of type string on string```
- It returns a valid array only after the user saves the plugin's settings via the admin interface. This array looks like: 
```php
array (
  'graphql_endpoint' => 'graphql',
  'restrict_endpoint_to_logged_in_users' => 'off',
  'batch_queries_enabled' => 'on',
  'batch_limit' => '10',
  'query_depth_enabled' => 'off',
  'query_depth_max' => 10,
  'query_analyzer_enabled' => 'off',
  'graphiql_enabled' => 'on',
  'show_graphiql_link_in_admin_bar' => 'on',
  'delete_data_on_deactivate' => 'on',
  'debug_mode_enabled' => 'off',
  'tracing_enabled' => 'off',
  'tracing_user_role' => 'administrator',
  'query_logs_enabled' => 'off',
  'query_log_user_role' => 'administrator',
  'public_introspection_enabled' => 'off',
)
```

## The fix

The proposed solution adds a safety check to ensure the option value is an array before accessing `['graphql_endpoint']`. If it's not, the fallback value `'graphql'` is used.
This prevents the crash when the option is missing or improperly initialized and ensures a more robust and fault-tolerant behavior.